### PR TITLE
Analysis type selections + lines on pole components

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,67 +4,55 @@ import { SearchComponent } from './components/search/search.component';
 import { ResultsComponent } from './components/results/results.component';
 import { DirectionSelectionComponent } from './components/direction-selection/direction-selection.component';
 import { PoleSelectionComponent } from './components/pole-selection/pole-selection.component';
+import { DirectionAnalysisSelectionComponent } from './components/direction-analysis-selection/direction-analysis-selection.component';
+import { PoleAnalysisSelectionComponent } from './components/pole-analysis-selection/pole-analysis-selection.component';
 
 export const routes: Routes = [
     { path: '', component: WelcomeScreenComponent },
     { path: 'search', component: SearchComponent },
     {
-        path: 'line/:routeLine', component: DirectionSelectionComponent,
-            children: [
-                {
-                    path: ':direction', redirectTo: '', //component: futurecomponent
-                    children: [
-                        {
-                            path: 'real_schedule', redirectTo: '', //component: futurecomponent
-                            children: [
-                                {
-                                    path: 'settings', redirectTo: '', //component: futurecomponent
-                                },
-                                {
-                                    path: 'results', redirectTo: '', //component: futurecomponent
-                                },
-                            ],
-                        },
-                        {
-                            path: 'mean_latency', redirectTo: '', //component: futurecomponent
-                            children: [
-                                {
-                                    path: 'settings', redirectTo: '', //component: futurecomponent
-                                },
-                                {
-                                    path: 'results', redirectTo: '', //component: futurecomponent
-                                },
-                            ],
-                        },
-                    ]
-                },
-            ]
+        path: 'line/:routeLine', component: DirectionSelectionComponent
     },
     {
-        path: 'stop/:routeStopName/:routeStopId', component: PoleSelectionComponent,
-            children: [
-                {
-                    path: ':poleNumber', redirectTo: '', //component: futurecomponent
-                    children: [
-                        {
-                            path: 'real_schedule', redirectTo: '', //component: futurecomponent
-                            children: [
-                                {
-                                    path: 'settings', redirectTo: '', //component: futurecomponent
-                                },
-                                {
-                                    path: 'results', redirectTo: '', //component: futurecomponent
-                                },
-                            ],
-                        },
-                        {
-                            path: 'lines', redirectTo: '', //component: futurecomponent
-                        },
-                    ]
-                },
-            ]
-
+        path: 'line/:routeLine/:direction', component: DirectionAnalysisSelectionComponent
+    },
+    {
+        path: 'line/:routeLine/:direction/real_schedule', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'line/:routeLine/:direction/real_schedule/settings', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'line/:routeLine/:direction/real_schedule/results', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'line/:routeLine/:direction/mean_latency', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'line/:routeLine/:direction/mean_latency/settings', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'line/:routeLine/:direction/mean_latency/results', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'stop/:routeStopId/:routeStopName', component: PoleSelectionComponent,
+    },
+    {
+        path: 'stop/:routeStopId/:routeStopName/:routePoleName', component: PoleAnalysisSelectionComponent,
+    },
+    {
+        path: 'stop/:routeStopId/:routeStopName/:poleNumber/real_schedule', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'stop/:routeStopId/:routeStopName/:poleNumber/real_schedule/settings', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'stop/:routeStopId/:routeStopName/:poleNumber/real_schedule/results', redirectTo: '' // component: FutureComponent
+    },
+    {
+        path: 'stop/:routeStopId/:routeStopName/:poleNumber/lines', redirectTo: '' // component: FutureComponent
     },
     //THIS PATH IS HERE TEMPORARLY 
-    { path: 'results/:line/:directionSwapped/:startStop/:endStop', component: ResultsComponent },  //TODO is there a more elegant way to construct this url parameters?
+    { path: 'results/:line/:directionSwapped/:startStop/:endStop', component: ResultsComponent },  // TODO: Refactor this route
 ];
+

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { DirectionSelectionComponent } from './components/direction-selection/di
 import { PoleSelectionComponent } from './components/pole-selection/pole-selection.component';
 import { DirectionAnalysisSelectionComponent } from './components/direction-analysis-selection/direction-analysis-selection.component';
 import { PoleAnalysisSelectionComponent } from './components/pole-analysis-selection/pole-analysis-selection.component';
+import { LinesOnPoleSelectionComponent } from './components/lines-on-pole-selection/lines-on-pole-selection.component';
 
 export const routes: Routes = [
     { path: '', component: WelcomeScreenComponent },
@@ -50,7 +51,7 @@ export const routes: Routes = [
         path: 'stop/:routeStopId/:routeStopName/:poleNumber/real_schedule/results', redirectTo: '' // component: FutureComponent
     },
     {
-        path: 'stop/:routeStopId/:routeStopName/:poleNumber/lines', redirectTo: '' // component: FutureComponent
+        path: 'stop/:routeStopId/:routeStopName/:routePoleName/lines', component: LinesOnPoleSelectionComponent,
     },
     //THIS PATH IS HERE TEMPORARLY 
     { path: 'results/:line/:directionSwapped/:startStop/:endStop', component: ResultsComponent },  // TODO: Refactor this route

--- a/src/app/components/direction-analysis-selection/direction-analysis-selection.component.html
+++ b/src/app/components/direction-analysis-selection/direction-analysis-selection.component.html
@@ -1,1 +1,24 @@
-<p>direction-analysis-selection works!</p>
+<div class="pole-analysis-type-selection-component">
+    @if (selectedDirectionFromRoute$ | async; as selectedDirection) {
+        <div class="header" style="display: flex;">
+            <h2> {{routeLine}} | {{selectedDirection.endStopName}}</h2>
+        </div>
+        <div class="selection-buttons-container">
+            <div class="selection-button" (click)="selectedAnalysisType.set(enum.TripTimeTable)" [class.selected]="selectedAnalysisType() === enum.TripTimeTable">
+                <div class="selection-header">
+                    Rzeczywisty rozkład przejazdu
+                </div>
+                Zobacz jak autobusy linii {{routeLine}} opóźniają się między przystankami dla wybranego przejazdu tej linii.
+            </div>
+            <div class="selection-button" (click)="selectedAnalysisType.set(enum.RouteStatistics)" [class.selected]="selectedAnalysisType() === enum.RouteStatistics">
+                <div class="selection-header">
+                    Analiza statystyczna trasy
+                </div>
+                Wybierz trasę linii {{routeLine}} i zobacz wyniki analizy statystycznej opóźnień (w tym średnią, medianę i kwantyle)
+            </div>
+        </div>
+    }
+    <div class="navigation-buttons">
+        <app-navigation-buttons [nextDisabled]="selectedAnalysisType() === enum.None" (next)="navigateToDirectionOptions()" (previous)="navigateToDirectionSelection()"/>
+    </div>
+</div>

--- a/src/app/components/direction-analysis-selection/direction-analysis-selection.component.html
+++ b/src/app/components/direction-analysis-selection/direction-analysis-selection.component.html
@@ -1,0 +1,1 @@
+<p>direction-analysis-selection works!</p>

--- a/src/app/components/direction-analysis-selection/direction-analysis-selection.component.scss
+++ b/src/app/components/direction-analysis-selection/direction-analysis-selection.component.scss
@@ -1,0 +1,32 @@
+@use '../../styles/shared-styles.scss' as *;
+@use '@angular/material' as mat;
+
+.pole-analysis-type-selection-component {
+    @extend %full-height-component;
+}
+
+.navigation-buttons {
+    @extend %navigation-buttons;
+}
+
+.selection-button {
+    background-color: white;
+    border: 1px, solid, black;
+    border-radius: 15px;
+    width: 80%;
+    height: 150px;
+    &.selected {
+        background-color: var(--sys-primary);
+        color: white;
+    }
+}
+
+.selection-header {
+    width: 90%;
+    height: 30px;
+    padding: 5px;
+    margin: 10px;
+    border-radius: 15px;
+    background-color: var(--sys-primary);
+    color: white;
+}

--- a/src/app/components/direction-analysis-selection/direction-analysis-selection.component.spec.ts
+++ b/src/app/components/direction-analysis-selection/direction-analysis-selection.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DirectionAnalysisSelectionComponent } from './direction-analysis-selection.component';
+
+describe('DirectionAnalysisSelectionComponent', () => {
+  let component: DirectionAnalysisSelectionComponent;
+  let fixture: ComponentFixture<DirectionAnalysisSelectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DirectionAnalysisSelectionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DirectionAnalysisSelectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/direction-analysis-selection/direction-analysis-selection.component.ts
+++ b/src/app/components/direction-analysis-selection/direction-analysis-selection.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-direction-analysis-selection',
+  standalone: true,
+  imports: [],
+  templateUrl: './direction-analysis-selection.component.html',
+  styleUrl: './direction-analysis-selection.component.scss'
+})
+export class DirectionAnalysisSelectionComponent {
+
+}

--- a/src/app/components/direction-analysis-selection/direction-analysis-selection.component.ts
+++ b/src/app/components/direction-analysis-selection/direction-analysis-selection.component.ts
@@ -1,12 +1,58 @@
-import { Component } from '@angular/core';
+import { Component, inject, Input, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ErrorDialogService } from '../../services/error-dialog.service';
+import { MapService } from '../../services/map.service';
+import { LineDataService } from '../../services/line-data.service';
+import { catchError, map, of, switchMap, tap } from 'rxjs';
+import { AsyncPipe } from '@angular/common';
+import { NavigationButtonsComponent } from "../navigation-buttons/navigation-buttons.component";
+
+enum AnalysisType {
+  TripTimeTable,
+  RouteStatistics,
+  None
+}
 
 @Component({
   selector: 'app-direction-analysis-selection',
   standalone: true,
-  imports: [],
+  imports: [AsyncPipe, NavigationButtonsComponent],
   templateUrl: './direction-analysis-selection.component.html',
   styleUrl: './direction-analysis-selection.component.scss'
 })
 export class DirectionAnalysisSelectionComponent {
+  private router = inject(Router);
+  private errorDialogService = inject(ErrorDialogService);
+  private mapService = inject(MapService);
+  private lineDataService = inject(LineDataService);
+  private activatedRoute = inject(ActivatedRoute);
 
+  @Input() routeLine!: string;
+
+  public enum: typeof AnalysisType = AnalysisType;
+
+  selectedAnalysisType = signal<AnalysisType>(AnalysisType.None)
+
+  selectedDirectionFromRoute$ = this.activatedRoute.params.pipe(
+    switchMap(paramMap => 
+      this.lineDataService.getLineData(paramMap['routeLine'], paramMap['direction']).pipe(
+        tap(lineData => {
+          this.mapService.drawRoute(lineData.shapes);
+          this.mapService.drawPoles(lineData.poles);
+        }),
+      )
+    ),
+    catchError(error => {
+      this.errorDialogService.openErrorDialog(error.message);
+      return of(null);
+    })
+  );
+
+  navigateToDirectionOptions(): void {
+	
+  }
+
+  navigateToDirectionSelection(): void {
+    this.router.navigate([`line/${this.activatedRoute.snapshot.params['routeLine']}`])
+  }
 }

--- a/src/app/components/direction-selection/direction-selection.component.html
+++ b/src/app/components/direction-selection/direction-selection.component.html
@@ -19,7 +19,7 @@
     <div class="navigation-buttons">
         <app-navigation-buttons
             [nextDisabled]="selectedDirection() === null"
-            (next)="navigateToLineAnalysisOptions()"
+            (next)="navigateToDirectionAnalysisOptions()"
             (previous)="navigateToLineSelection()">
         </app-navigation-buttons>
     </div>

--- a/src/app/components/direction-selection/direction-selection.component.html
+++ b/src/app/components/direction-selection/direction-selection.component.html
@@ -4,7 +4,7 @@
             class="stop-line-button"
             mat-stroked-button
             (click)="selectDirection(directionData[0])"
-            [class.selected]="directionData[0].endStopName === selectedDirection()">
+            [class.selected]="directionData[0].direction === selectedDirection()">
             {{ routeLine }} {{ directionData[0].endStopName }}
         </button>
 
@@ -12,7 +12,7 @@
             class="stop-line-button"
             mat-stroked-button
             (click)="selectDirection(directionData[1])"
-            [class.selected]="directionData[1].endStopName === selectedDirection()">
+            [class.selected]="directionData[1].direction === selectedDirection()">
             {{ routeLine }} {{ directionData[1].endStopName }}
         </button>
     }

--- a/src/app/components/direction-selection/direction-selection.component.ts
+++ b/src/app/components/direction-selection/direction-selection.component.ts
@@ -27,7 +27,7 @@ export class DirectionSelectionComponent {
   
   @Input() routeLine!: string;
   
-  selectedDirection = signal<string | null>(null);
+  selectedDirection = signal<boolean | null>(null);
 
   directionsData$ = this.activatedRoute.paramMap.pipe(
     switchMap(paramMap => {
@@ -44,7 +44,7 @@ export class DirectionSelectionComponent {
   );
 
   selectDirection(lineData: LineData) {
-    this.selectedDirection.set(lineData.endStopName);
+    this.selectedDirection.set(lineData.direction);
     this.mapService.drawRoute(lineData.shapes);
     this.mapService.drawPoles(lineData.poles);
   }

--- a/src/app/components/direction-selection/direction-selection.component.ts
+++ b/src/app/components/direction-selection/direction-selection.component.ts
@@ -49,8 +49,8 @@ export class DirectionSelectionComponent {
     this.mapService.drawPoles(lineData.poles);
   }
 
-  navigateToLineAnalysisOptions(): void {
-    
+  navigateToDirectionAnalysisOptions(): void {
+    this.router.navigate([`${this.selectedDirection()}`], { relativeTo: this.activatedRoute });
   }
 
   navigateToLineSelection(): void {

--- a/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.html
+++ b/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.html
@@ -1,0 +1,1 @@
+<p>lines-on-pole-selection works!</p>

--- a/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.html
+++ b/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.html
@@ -1,1 +1,21 @@
-<p>lines-on-pole-selection works!</p>
+<div class="lines-on-pole-selection-component">
+    @if (selectedPoleFromRoute$ | async; as selectedPole) {
+        <div class="header" style="display: flex;">
+            <h2> {{selectedPole.name}} </h2>
+        </div>
+        @if (linesOnPole$ | async; as linesOnPole) {
+            @for (line of linesOnPole; track $index) {
+                <button
+                    class="stop-line-button"
+                    mat-stroked-button
+                    [class.selected]="line === lineSelection()"
+                    (click)="lineSelection.set(line)">
+                    {{line}}
+                </button>
+            } 
+        }
+    }
+    <div class="navigation-buttons">
+        <app-navigation-buttons [nextDisabled]="!lineSelection()" (next)="navigateToDirectionSelection()" (previous)="navigateToPoleAnalysisSelection()"/>
+    </div>
+</div>

--- a/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.scss
+++ b/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.scss
@@ -1,0 +1,27 @@
+@use '../../styles/shared-styles.scss' as *;
+@use '@angular/material' as mat;
+
+.lines-on-pole-selection-component {
+    @extend %full-height-component;
+}
+
+.navigation-buttons {
+    @extend %navigation-buttons;
+}
+
+.stop-line-button {
+    &.selected {
+        background-color: var(--sys-primary);
+        color: white;
+    }
+}
+
+.selection-header {
+    width: 90%;
+    height: 30px;
+    padding: 5px;
+    margin: 10px;
+    border-radius: 15px;
+    background-color: var(--sys-primary);
+    color: white;
+}

--- a/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.spec.ts
+++ b/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LinesOnPoleSelectionComponent } from './lines-on-pole-selection.component';
+
+describe('LinesOnPoleSelectionComponent', () => {
+  let component: LinesOnPoleSelectionComponent;
+  let fixture: ComponentFixture<LinesOnPoleSelectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LinesOnPoleSelectionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LinesOnPoleSelectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.ts
+++ b/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.ts
@@ -1,12 +1,67 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ErrorDialogService } from '../../services/error-dialog.service';
+import { map } from 'rxjs/operators';
+import { MapService } from '../../services/map.service';
+import { PolesOnStopService } from '../../services/poles-on-stop.service';
+import { catchError, filter, of, switchMap, tap } from 'rxjs';
+import { PoleDetails } from '../../interfaces/line-data';
+import { LinesOnPoleService } from '../../services/lines-on-pole.service';
+import { AsyncPipe } from '@angular/common';
+import { MapComponent } from "../map/map.component";
+import { NavigationButtonsComponent } from "../navigation-buttons/navigation-buttons.component";
+import { MatIcon } from '@angular/material/icon';
+import { MatButton } from '@angular/material/button';
 
 @Component({
   selector: 'app-lines-on-pole-selection',
   standalone: true,
-  imports: [],
+  imports: [AsyncPipe, MapComponent, NavigationButtonsComponent, MatIcon, MatButton],
   templateUrl: './lines-on-pole-selection.component.html',
   styleUrl: './lines-on-pole-selection.component.scss'
 })
 export class LinesOnPoleSelectionComponent {
+  private router = inject(Router);
+  private errorDialogService = inject(ErrorDialogService);
+  private mapService = inject(MapService);
+  private polesOnStopService = inject(PolesOnStopService);
+  private linesOnPoleService = inject(LinesOnPoleService);
+  private activatedRoute = inject(ActivatedRoute);
 
+  lineSelection = signal<string>('');
+
+  selectedPoleFromRoute$ = this.activatedRoute.params.pipe(
+    switchMap(paramMap => 
+      this.polesOnStopService.getPolesOnStop(paramMap['routeStopId']).pipe(
+        map(poles => poles.find(pole => pole.name === paramMap['routePoleName'])),
+        filter((pole): pole is PoleDetails => !!pole),
+        tap(pole => {
+          this.mapService.clearLayers();
+          this.mapService.drawPoles([pole]);
+          this.mapService.setSelectedPole(pole);
+        }),
+      )
+    ),
+    catchError(error => {
+      this.errorDialogService.openErrorDialog(error.message);
+      return of(null);
+    })
+  );
+
+  linesOnPole$ = this.selectedPoleFromRoute$.pipe(
+    switchMap(pole => this.linesOnPoleService.getLinesOnPole(pole!.id)),
+    catchError(error => {
+      this.errorDialogService.openErrorDialog(error.message);
+      return of(null);
+    })
+  );
+
+  navigateToPoleAnalysisSelection(): void {
+    const params = this.activatedRoute.snapshot.params;
+    this.router.navigate([`stop/${params['routeStopId']}/${params['routeStopName']}/${this.mapService.selectedPole()?.name}`]);
+  }
+  
+  navigateToDirectionSelection(): void {
+    this.router.navigate([`line/${this.lineSelection()}`]);
+  }
 }

--- a/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.ts
+++ b/src/app/components/lines-on-pole-selection/lines-on-pole-selection.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-lines-on-pole-selection',
+  standalone: true,
+  imports: [],
+  templateUrl: './lines-on-pole-selection.component.html',
+  styleUrl: './lines-on-pole-selection.component.scss'
+})
+export class LinesOnPoleSelectionComponent {
+
+}

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -173,6 +173,7 @@ export class MapComponent implements OnInit {
       this.poleMarkers.push(stopMarker);
       stopMarker.addTo(this.map);
       this.markersGroup.addLayer(stopMarker);
+      polesToDraw.length > 1 ? this.poleMarkers.push(stopMarker) : stopMarker.openPopup();
     });
     this.map.fitBounds(bounds.pad(0.2));
   }

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.html
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.html
@@ -20,6 +20,9 @@
         </div>
     }
     <div class="navigation-buttons">
-        <app-navigation-buttons [nextDisabled]="selectedAnalysisType() === enum.None" (next)="navigateToPoleOptions()" (previous)="navigateToPoleSelection()"/>
+        <app-navigation-buttons
+            [nextDisabled]="selectedAnalysisType() === enum.None"
+            (next)="selectedAnalysisType() === enum.Line ? navigateToLinesOnPoleSelection() : navigateToPoleOptions()"
+            (previous)="navigateToPoleSelection()"/>
     </div>
 </div>

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.html
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.html
@@ -1,0 +1,1 @@
+<p>pole-analysis-selection works!</p>

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.html
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.html
@@ -1,1 +1,25 @@
-<p>pole-analysis-selection works!</p>
+<div class="pole-analysis-type-selection-component">
+    @if (selectedPoleFromRoute$ | async; as selectedPole) {
+        <div class="header" style="display: flex;">
+            <h2> {{selectedPole.name}} </h2>
+        </div>
+        <div class="selection-buttons-container">
+            <div class="selection-button" (click)="selectedAnalysisType.set(enum.StopTimetable)" [class.selected]="selectedAnalysisType() === enum.StopTimetable">
+                <div class="selection-header">
+                    Rzeczywisty rozkład przystanku
+                </div>
+                Zobacz jak statystycznie wyglądają godziny przejazdów wybranej linii zatrzymującej się na przystanku
+                {{selectedPole.name}}.
+            </div>
+            <div class="selection-button" (click)="selectedAnalysisType.set(enum.Line)" [class.selected]="selectedAnalysisType() === enum.Line">
+                <div class="selection-header">
+                    Analiza linii autobusowej
+                </div>
+                Wybierz linię przejeżdżającą przez ten przystanek, a następnie rodzaj analizy dla tej linii.
+            </div>
+        </div>
+    }
+    <div class="navigation-buttons">
+        <app-navigation-buttons [nextDisabled]="selectedAnalysisType() === enum.None" (next)="navigateToPoleOptions()" (previous)="navigateToPoleSelection()"/>
+    </div>
+</div>

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.scss
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.scss
@@ -1,0 +1,32 @@
+@use '../../styles/shared-styles.scss' as *;
+@use '@angular/material' as mat;
+
+.pole-analysis-type-selection-component {
+    @extend %full-height-component;
+}
+
+.navigation-buttons {
+    @extend %navigation-buttons;
+}
+
+.selection-button {
+    background-color: white;
+    border: 1px, solid, black;
+    border-radius: 15px;
+    width: 80%;
+    height: 150px;
+    &.selected {
+        background-color: var(--sys-primary);
+        color: white;
+    }
+}
+
+.selection-header {
+    width: 90%;
+    height: 30px;
+    padding: 5px;
+    margin: 10px;
+    border-radius: 15px;
+    background-color: var(--sys-primary);
+    color: white;
+}

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.spec.ts
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PoleAnalysisSelectionComponent } from './pole-analysis-selection.component';
+
+describe('PoleAnalysisSelectionComponent', () => {
+  let component: PoleAnalysisSelectionComponent;
+  let fixture: ComponentFixture<PoleAnalysisSelectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PoleAnalysisSelectionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PoleAnalysisSelectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
@@ -1,12 +1,60 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { NavigationButtonsComponent } from "../navigation-buttons/navigation-buttons.component";
+import { ActivatedRoute, Router } from '@angular/router';
+import { MapService } from '../../services/map.service';
+import { PolesOnStopService } from '../../services/poles-on-stop.service';
+import { PoleDetails } from '../../interfaces/line-data';
+import { ErrorDialogService } from '../../services/error-dialog.service';
+import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+import { AsyncPipe } from '@angular/common';
+
+enum AnalysisType {
+  StopTimetable,
+  Line,
+  None
+}
 
 @Component({
-  selector: 'app-pole-analysis-selection',
+  selector: 'app-pole-analysis-type-selection',
   standalone: true,
-  imports: [],
+  imports: [NavigationButtonsComponent, AsyncPipe],
   templateUrl: './pole-analysis-selection.component.html',
   styleUrl: './pole-analysis-selection.component.scss'
 })
 export class PoleAnalysisSelectionComponent {
+  private router = inject(Router);
+  private errorDialogService = inject(ErrorDialogService);
+  private mapService = inject(MapService);
+  private polesOnStopService = inject(PolesOnStopService);
+  private activatedRoute = inject(ActivatedRoute);
 
+  public enum: typeof AnalysisType = AnalysisType;
+
+  selectedAnalysisType = signal<AnalysisType>(AnalysisType.None)
+
+  selectedPoleFromRoute$ = this.activatedRoute.params.pipe(
+    switchMap(paramMap => 
+      this.polesOnStopService.getPolesOnStop(paramMap['routeStopId']).pipe(
+        map(poles => poles.find(pole => pole.name === paramMap['routePoleName'])),
+        filter((pole): pole is PoleDetails => !!pole),
+        tap(pole => {
+          this.mapService.clearLayers();
+          this.mapService.drawPoles([pole]);
+          this.mapService.setSelectedPole(pole);
+        }),
+      )
+    ),
+    catchError(error => {
+      this.errorDialogService.openErrorDialog(error.message);
+      return of(null);
+    })
+  );
+
+  navigateToPoleOptions(): void {
+	
+  }
+
+  navigateToPoleSelection(): void {
+    this.router.navigate([`stop/${this.activatedRoute.snapshot.params['routeStopId']}/${this.activatedRoute.snapshot.params['routeStopName']}`])
+  }
 }

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
@@ -40,7 +40,6 @@ export class PoleAnalysisSelectionComponent {
         tap(pole => {
           this.mapService.clearLayers();
           this.mapService.drawPoles([pole]);
-          this.mapService.setSelectedPole(pole);
         }),
       )
     ),

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
@@ -51,7 +51,11 @@ export class PoleAnalysisSelectionComponent {
   );
 
   navigateToPoleOptions(): void {
-	
+    
+  }
+
+  navigateToLinesOnPoleSelection(): void {
+    this.router.navigate([`lines`], { relativeTo: this.activatedRoute })
   }
 
   navigateToPoleSelection(): void {

--- a/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
+++ b/src/app/components/pole-analysis-selection/pole-analysis-selection.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-pole-analysis-selection',
+  standalone: true,
+  imports: [],
+  templateUrl: './pole-analysis-selection.component.html',
+  styleUrl: './pole-analysis-selection.component.scss'
+})
+export class PoleAnalysisSelectionComponent {
+
+}

--- a/src/app/components/pole-selection/pole-selection.component.ts
+++ b/src/app/components/pole-selection/pole-selection.component.ts
@@ -43,7 +43,7 @@ export class PoleSelectionComponent implements OnInit {
   }
 
   navigateToPoleAnalysisOptions(): void {
-    
+    this.router.navigate([`${this.mapService.selectedPole()?.name}`], { relativeTo: this.activatedRoute });
   }
 
   navigateToLineSelection(): void {

--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -134,7 +134,7 @@ export class SearchComponent {
   
   navigateToLineOrStop(): void {
     if (this.stopSelection() !== null) {
-      this.router.navigate([`stop/${this.stopSelection()?.name}/${this.stopSelection()?.id}`]);
+      this.router.navigate([`stop/${this.stopSelection()?.id}/${this.stopSelection()?.name}`]);
     } else {
       this.router.navigate([`line/${this.lineSelection()}`]);
     }

--- a/src/app/services/lines-on-pole.service.spec.ts
+++ b/src/app/services/lines-on-pole.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LinesOnPoleService } from './lines-on-pole.service';
+
+describe('LinesOnPoleService', () => {
+  let service: LinesOnPoleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LinesOnPoleService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/lines-on-pole.service.ts
+++ b/src/app/services/lines-on-pole.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { catchError, Observable, shareReplay, throwError } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LinesOnPoleService {
+  private http = inject(HttpClient);
+
+  getLinesOnPole(poleId: number): Observable<string[]> {
+    return this.http.get<string[]>(`/api/v1/poles/${poleId}/lines/`)
+      .pipe(
+        shareReplay(),
+        catchError(this.handleError)
+      );
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    if (error.status === 0) {
+      console.error('A client-side or network error occurred:', error.error);
+    } else {
+      console.error(`Backend returned code ${error.status}`);
+    }
+    return throwError(() => new Error('An error occurred while fetching lines on pole'));
+  }
+}


### PR DESCRIPTION
Closes #3 

This pr implements marked figma components
![image](https://github.com/user-attachments/assets/1d910aa9-abad-4bb5-ab8b-032cabdc71c2)

Routing had to be changed that way becase we are not using child components

Selected analysis type is handled by enums, we can convert this to boolean for example but i think this way it's more readable

