### PR TITLE
Add the Azure deployment token to close_pull_request_job

### DIFF
--- a/.github/workflows/azure-static-web-apps-blue-grass-0ce1a4e03.yml
+++ b/.github/workflows/azure-static-web-apps-blue-grass-0ce1a4e03.yml
@@ -54,4 +54,5 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLUE_GRASS_0CE1A4E03 }}
           action: "close"


### PR DESCRIPTION
This way staging environments on Azure should be automatically deleted whenever a pull request for them is closed