### PR TITLE
Fix Azure deployment action to properly remove staging environments on pull request close

### DIFF
--- a/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - azure-deployment-action-fix
+      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - azure-deployment-action-fix
+      - main
 
 jobs:
   build_and_deploy_job:
@@ -29,8 +29,8 @@ jobs:
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
-          api_location: "" # Api source code path - optional
           output_location: "dist/jakniedojade/browser" # Built app content directory - optional
+          skip_api_build: true
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
@@ -31,6 +31,7 @@ jobs:
           app_location: "/" # App source code path
           output_location: "dist/jakniedojade/browser" # Built app content directory - optional
           skip_api_build: true
+          production_branch: "main"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
@@ -1,0 +1,46 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+      - azure-deployment-action-fix
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - azure-deployment-action-fix
+
+jobs:
+  build_and_deploy_job:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: false
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_COAST_0A2E5EC03 }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: "upload"
+          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
+          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
+          app_location: "/" # App source code path
+          api_location: "" # Api source code path - optional
+          output_location: "dist/jakniedojade/browser" # Built app content directory - optional
+          ###### End of Repository/Build Configurations ######
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_COAST_0A2E5EC03 }}
+          action: "close"

--- a/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-coast-0a2e5ec03.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - main
+      - azure-deployment-action-fix
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - main
+      - azure-deployment-action-fix
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
Currently because our Azure deployment workflow used github for Deployment authorization policy, we got an error whenever the actions tried to remove unneded staging environments on pull request close or merge.

![image](https://github.com/user-attachments/assets/6d7ed77c-a378-4341-ad98-cc9f1c8f9481)

This resulted in our 3 staging environment slots getting filled and us being unable to deploy new changes to production (we got an "internal server error").

![image](https://github.com/user-attachments/assets/bdcf6e5c-3849-4613-b3b1-10bdb5c0dd85)

This pull request fixes this by using Azure for Deployment authorization policy instead. Moves our static web app to a new service and adds some stability improvements in the workflow configuration.