### PR TITLE
Leaflet drawing improvements

### DIFF
--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -94,6 +94,7 @@ export class MapComponent implements OnInit {
   }
 
   private tempPoles: any = [] //used to store removed gray poles green route overwrites gray one
+  private drawingTimeout: any;
 
   public clearMapLayers() {
     this.routeMarkersGroup.clearLayers();
@@ -101,6 +102,8 @@ export class MapComponent implements OnInit {
     this.mapService.routeDrawn.set(false);
     this.poleMarkers = [];
     this.tempPoles = [];
+
+    clearTimeout(this.drawingTimeout);
   }
 
   public drawRoute(shapes: [number, number][], grayPolyline: boolean = false): void {
@@ -126,8 +129,10 @@ export class MapComponent implements OnInit {
       snakingSpeed: 1800
     } as L.PolylineOptions);
 
-    this.polyline.addTo(this.map).snakeIn();
-    this.routeMarkersGroup.addLayer(this.polyline);
+    this.drawingTimeout = setTimeout(() => {
+      this.polyline.addTo(this.map).snakeIn();
+      this.routeMarkersGroup.addLayer(this.polyline);
+    }, 300)
   }
   
   public drawPoles(polesToDraw: PoleDetails[], grayIcons: boolean = false): void {

--- a/src/app/pages/line/direction-analysis-selection/direction-analysis-selection.component.ts
+++ b/src/app/pages/line/direction-analysis-selection/direction-analysis-selection.component.ts
@@ -49,8 +49,7 @@ export class DirectionAnalysisSelectionComponent {
         map(lineData => lineData.find(data => data.direction.toString() === paramMap['direction'])),
         tap(lineData => {
           if (lineData && !this.mapService.routeDrawn()) {
-            this.mapService.drawRoute(lineData.path.coordinates);
-            this.mapService.drawPoles(lineData.poles);
+            this.mapService.drawRoute(lineData.path.coordinates, lineData.poles);
           }
         }),
       )

--- a/src/app/pages/line/direction-meanlatency-settings/direction-meanlatency-settings.component.ts
+++ b/src/app/pages/line/direction-meanlatency-settings/direction-meanlatency-settings.component.ts
@@ -84,8 +84,7 @@ export class DirectionMeanlatencySettingsComponent {
         map(lineData => lineData.find(data => data.direction.toString() === paramMap['direction'])),
         tap(lineData => {
           if (lineData) {
-            this.mapService.drawRoute(lineData.path.coordinates, true);
-            this.mapService.drawPoles(lineData.poles, true);
+            this.mapService.drawRoute(lineData.path.coordinates, lineData.poles, true, true);
           }
         }),
       )

--- a/src/app/pages/line/direction-meanlatency-settings/direction-meanlatency-settings.component.ts
+++ b/src/app/pages/line/direction-meanlatency-settings/direction-meanlatency-settings.component.ts
@@ -84,7 +84,7 @@ export class DirectionMeanlatencySettingsComponent {
         map(lineData => lineData.find(data => data.direction.toString() === paramMap['direction'])),
         tap(lineData => {
           if (lineData) {
-            this.mapService.drawRoute(lineData.path.coordinates, lineData.poles, true, true);
+            this.mapService.drawRoute(lineData.path.coordinates, lineData.poles, true);
           }
         }),
       )

--- a/src/app/pages/line/direction-selection/direction-selection.component.ts
+++ b/src/app/pages/line/direction-selection/direction-selection.component.ts
@@ -57,8 +57,7 @@ export class DirectionSelectionComponent {
 
   selectDirection(lineData: LineData) {
     this.selectedDirection.set(lineData);
-    this.mapService.drawRoute(lineData.path.coordinates);
-    this.mapService.drawPoles(lineData.poles);
+    this.mapService.drawRoute(lineData.path.coordinates, lineData.poles);
   }
 
   navigateToDirectionAnalysisOptions(): void {

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -25,10 +25,10 @@ export class MapService {
     this.mapComponent!.clearSlicedRouteLayers();
   }
 
-  drawRoute(shapes: [number, number][], poles: PoleDetails[], grayPolyline: boolean = false, grayPoleIcons: boolean = false): void {
+  drawRoute(shapes: [number, number][], poles: PoleDetails[], grayRoute: boolean = false): void {
     const mappedData = this.mapPolesToShapes(poles, shapes, poles[0], poles[poles.length - 1]);
-    this.mapComponent!.drawRoute(mappedData.shapes, grayPolyline);
-    this.mapComponent!.drawPoles(mappedData.poles, grayPoleIcons);
+    this.mapComponent!.drawRoute(mappedData.shapes, grayRoute);
+    this.mapComponent!.drawPoles(mappedData.poles, grayRoute);
   }
 
   drawPoles(poles: PoleDetails[], grayIcons: boolean = false): void {

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -27,7 +27,6 @@ export class MapService {
 
   drawRoute(shapes: [number, number][], grayPolyline: boolean = false): void {
     this.mapComponent!.drawRoute(shapes, grayPolyline);
-    this.routeDrawn.set(grayPolyline ? false : true);
   }
 
   drawPoles(poles: PoleDetails[], grayIcons: boolean = false): void {

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -25,8 +25,10 @@ export class MapService {
     this.mapComponent!.clearSlicedRouteLayers();
   }
 
-  drawRoute(shapes: [number, number][], grayPolyline: boolean = false): void {
-    this.mapComponent!.drawRoute(shapes, grayPolyline);
+  drawRoute(shapes: [number, number][], poles: PoleDetails[], grayPolyline: boolean = false, grayPoleIcons: boolean = false): void {
+    const mappedData = this.mapPolesToShapes(poles, shapes, poles[0], poles[poles.length - 1]);
+    this.mapComponent!.drawRoute(mappedData.shapes, grayPolyline);
+    this.mapComponent!.drawPoles(mappedData.poles, grayPoleIcons);
   }
 
   drawPoles(poles: PoleDetails[], grayIcons: boolean = false): void {
@@ -45,11 +47,11 @@ export class MapService {
   }
   
   drawSlicedRoute(shapes: [number, number][], poles: PoleDetails[], startingPole: PoleDetails, endingPole: PoleDetails) {
-    const data = this.sliceRoute(poles, shapes, startingPole, endingPole);
+    const data = this.mapPolesToShapes(poles, shapes, startingPole, endingPole);
     this.mapComponent!.drawSlicedRoute(data.shapes, data.poles);
   }
 
-  private sliceRoute(poles: PoleDetails[], shapes: [number, number][], startingPole: PoleDetails, endingPole: PoleDetails) {
+  private mapPolesToShapes(poles: PoleDetails[], shapes: [number, number][], startingPole: PoleDetails, endingPole: PoleDetails) {
     const calculateDistance = (x1: number, y1: number, x2: number, y2: number): number => {
       return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
     }


### PR DESCRIPTION
Closes #48 
Closes #44 

Route is now being drawn after 300ms delay. This gives leaflet a time window to complete any map zoom or move animations before drawing animation begins. Unfortunetely we cant use map 'moveend' event as not every map view change triggers it.
Timeout cancellation is needed in case someone will be fast enough to call the drawing function again in less than 300ms 

All poles mapped to shapes - drawing route and poles is now done with one function